### PR TITLE
Minor fixes discovered from internal testing.

### DIFF
--- a/src/Salesforce.VisualStudio.Services/ConnectedService/SalesforceConnectedServiceHandler.cs
+++ b/src/Salesforce.VisualStudio.Services/ConnectedService/SalesforceConnectedServiceHandler.cs
@@ -29,7 +29,7 @@ namespace Salesforce.VisualStudio.Services.ConnectedService
     // Exclude the following C# projects - Windows Store, Windows Phone, Universal, Shared Class Libs, ASP.net 5, Silverlight
     [ConnectedServiceHandlerExport(
         Constants.ProviderId,
-        AppliesTo = "CSharp + !WindowsAppContainer + !WindowsPhone + !SharedAssetsProject + !MultiTarget + !ProjectK",
+        AppliesTo = "CSharp + !WindowsAppContainer + !WindowsPhone + !SharedAssetsProject + !MultiTarget + !DNX",
         SupportedProjectTypes = "!A1591282-1198-4647-A2B1-27E5FF5F6F3B" /* Excluding Silverlight */)]
     internal class SalesforceConnectedServiceHandler : ConnectedServiceHandler
     {

--- a/src/Salesforce.VisualStudio.Services/ConnectedService/SalesforceConnectedServiceHandler.cs
+++ b/src/Salesforce.VisualStudio.Services/ConnectedService/SalesforceConnectedServiceHandler.cs
@@ -167,7 +167,7 @@ namespace Salesforce.VisualStudio.Services.ConnectedService
 
         private async Task AddNuGetPackagesAsync(ConnectedServiceHandlerContext context, Project project)
         {
-            IEnumerable<IVsPackageMetadata> installedPackages = this.PackageInstallerServices.GetInstalledPackages();
+            IEnumerable<IVsPackageMetadata> installedPackages = this.PackageInstallerServices.GetInstalledPackages(project);
             Dictionary<string, string> packagesToInstall = new Dictionary<string, string>();
 
             foreach (Tuple<string, Version> requiredPackage in SalesforceConnectedServiceHandler.requiredPackages)


### PR DESCRIPTION
Fix NuGet package installation to look at the project when determining which packages to install.
Previously, package installation would look at the entire solution, so if another project in the solution had a package installed it would not be installed to the project that was having the Salesforce service added to it.

Update handler to use final version of ProjectK capability.
For RTM, ASP.NET 5 projects finalized their project capability as "DNX" and
removed the "ProjectK" capability.  Update accordingly so we are disabled
on ASP.NET 5 projects.
