### PR TITLE
Incorrect version of api. Updated the version of API and Metadata to get latest version of objects

### DIFF
--- a/src/Salesforce.VisualStudio.Services/ConnectedService/Constants.cs
+++ b/src/Salesforce.VisualStudio.Services/ConnectedService/Constants.cs
@@ -20,8 +20,9 @@
         // Changing it here would break that functionality.
         public const string ProviderId = "Salesforce.ForceDotCom";
 
-        public const string SalesforceApiVersion = "32.0";
-        public const string SalesforceApiVersionWithPrefix = "v32.0";
+        //Updated the version from 32.0 to 37.0
+        public const string SalesforceApiVersion = "37.0";
+        public const string SalesforceApiVersionWithPrefix = "v37.0";
 
         public const string ServiceInstanceNameFormat = "Salesforce{0}";
         public const string ModelsName = "Models";


### PR DESCRIPTION
Currently the Sales Force API version ad metadata version is set to v32.0 in the constants file. Updated the code make v37.0